### PR TITLE
Increase epsilon

### DIFF
--- a/test/parex_test.exs
+++ b/test/parex_test.exs
@@ -25,7 +25,7 @@ defmodule ParexTest do
     # :timer.tc returns microseconds 
     # :timer.sleep takes milliseconds
 
-    epsilon = 5
+    epsilon = 50
     # It's not perfectly parallel, there is a minor overhead
 
     assert time < (5000 + epsilon)*microseconds_per_milliseconds


### PR DESCRIPTION
Hi, it's a nice one. How do you think about increasing the epsilon a little more (ex. 1%)? The test is sometimes fails in my relatively new MacBook pro environment. 

```
% mix test
  1) test it should run functions in parallel (ParexTest)
     test/parex_test.exs:13
     Assertion with < failed
     code: time < (5000 + epsilon) * microseconds_per_milliseconds
     lhs:  5006288
     rhs:  5005000
     stacktrace:
       test/parex_test.exs:31
```
